### PR TITLE
Include required dependencies for testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,12 @@
   "devDependencies": {
     "chai": "^3.4.1",
     "codecov.io": "^0.1.6",
+    "istanbul": "^0.4.3",
     "jsdom": "^7.0.2",
     "mocha": "^2.3.4",
     "mocha-jsdom": "^1.0.0",
     "sinon": "^1.17.2",
-    "sinon-chai": "^2.8.0"
+    "sinon-chai": "^2.8.0",
+    "standard": "^7.1.2"
   }
 }


### PR DESCRIPTION
I added some dependencies to the `devDependencies` that are required for testing but only work if installed globally.

Excluding global dependencies from package.json can save some space, but it can discourage new contributors who don't know what to do when they `npm run <something>` and everything immediately fails.