### PR TITLE
Simplify test running and don't depend on a shell script

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,4 +3,4 @@ machine:
     version: 4
 test:
   override:
-    - standard && istanbul cover ./node_modules/mocha/bin/_mocha ./test/*.spec.js -- -R spec && cat ./coverage/coverage.json | ./node_modules/codecov.io/bin/codecov.io.js
+    - npm test && cat ./coverage/coverage.json | ./node_modules/codecov.io/bin/codecov.io.js

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Basic virtual dom algorithm",
   "main": "index.js",
   "scripts": {
-    "test": "sh ./test.sh",
+    "test": "standard && npm run cover",
     "cover": "istanbul cover ./node_modules/mocha/bin/_mocha -- -R spec",
     "dev": "nodemon --watch lib --watch test --watch index.js --exec npm test",
     "build": "browserify simple-virtual-dom.js -o dist/bundle.js"

--- a/test.sh
+++ b/test.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-standard && istanbul cover ./node_modules/mocha/bin/_mocha ./test/*.spec.js -- -R spec


### PR DESCRIPTION
I simplified the test code a little by making the circleci test just depend on `npm test` instead of having it's own copy of the coverage command.

This also enabled removal of `test.sh` which improves compatibility because not all systems support shell scripts.